### PR TITLE
Add types and runtime dependencies

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,12 +1,12 @@
 import { Text, View, StyleSheet } from 'react-native';
-import { multiply } from 'react-native-deepgram';
+import { configure } from 'react-native-deepgram';
 
-const result = multiply(3, 7);
+configure({ apiKey: 'YOUR_API_KEY' });
 
 export default function App() {
   return (
     <View style={styles.container}>
-      <Text>Result: {result}</Text>
+      <Text>Deepgram Example</Text>
     </View>
   );
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,10 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
+  "dependencies": {
+    "@deepgram/sdk": "^4.7.0",
+    "expo-av": "^15.1.7"
+  },
   "devDependencies": {
     "@commitlint/config-conventional": "^19.6.0",
     "@eslint/compat": "^1.2.7",

--- a/src/NativeDeepgram.ts
+++ b/src/NativeDeepgram.ts
@@ -1,14 +1,22 @@
-import { NativeModules } from 'react-native'
+import { NativeModules } from 'react-native';
 
 interface DeepgramNative {
-  startRecording(): Promise<void>
-  stopRecording(): Promise<void>
-  playPcm(chunk: number[]): Promise<void>
+  startRecording(): Promise<void>;
+  stopRecording(): Promise<void>;
+  startAudio(): Promise<void>;
+  stopAudio(): Promise<void>;
+  playAudioChunk(chunk: string): Promise<void>;
 }
 
-const LINKING_ERROR =
-  `react-native-deepgram: Native code not linked—did you run “pod install” & rebuild?`
+const LINKING_ERROR = `react-native-deepgram: Native code not linked—did you run “pod install” & rebuild?`;
 
 export const Deepgram: DeepgramNative =
   NativeModules.DeepgramNative ??
-  new Proxy({}, { get() { throw new Error(LINKING_ERROR) } }) as any
+  (new Proxy(
+    {},
+    {
+      get() {
+        throw new Error(LINKING_ERROR);
+      },
+    }
+  ) as any);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
-export { default as useDeepgramConversation } from './useDeepgramConversation';
+export { useDeepgramConversation } from './useDeepgramConversation';
 export { Deepgram } from './NativeDeepgram';
 
 export const configure = (opts: { apiKey: string }) => {
-  globalThis.__DEEPGRAM_API_KEY__ = opts.apiKey;
+  (globalThis as any).__DEEPGRAM_API_KEY__ = opts.apiKey;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,11 @@
+export type ConversationPhrase = {
+  role: string;
+  text: string;
+};
+
+export interface VoiceAgentController {
+  sendInitialIntructions(instructions: string): Promise<void>;
+  setInitialConversationPhrases(phrases: ConversationPhrase[]): Promise<void>;
+  makeAgentSay(text: string): Promise<void>;
+  startConversation(): Promise<void>;
+}

--- a/src/types/use-conversation-hook.ts
+++ b/src/types/use-conversation-hook.ts
@@ -1,0 +1,9 @@
+export type Message = {
+  role: string;
+  content: string;
+  timestamp: number;
+};
+
+export type UseConversationHook<Props = any, Return = any> = (
+  props: Props
+) => Return;


### PR DESCRIPTION
## Summary
- add missing `types` folder with TypeScript definitions
- add runtime deps for `expo-av` and `@deepgram/sdk`
- expose `useDeepgramConversation` correctly
- define extra native methods and cleanup types
- update example to use new API

## Testing
- `yarn typecheck`
- `yarn lint --fix`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68656ff1b7b48326b4800426c5de4b24