### PR TITLE
Add Deepgram native modules and Expo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,22 @@ npm install react-native-deepgram
 
 
 ```js
-import { multiply } from 'react-native-deepgram';
+import { useDeepgramConversation, configure } from 'react-native-deepgram';
 
-// ...
+configure({ apiKey: 'YOUR_DEEPGRAM_API_KEY' });
+const { startSession, stopSession } = useDeepgramConversation({
+  onMessage: console.log,
+});
+```
 
-const result = multiply(3, 7);
+When using Expo, include the provided config plugin in your `app.json`:
+
+```json
+{
+  "expo": {
+    "plugins": ["react-native-deepgram"]
+  }
+}
 ```
 
 

--- a/android/src/main/java/com/deepgram/DeepgramModule.kt
+++ b/android/src/main/java/com/deepgram/DeepgramModule.kt
@@ -1,23 +1,193 @@
 package com.deepgram
 
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.AudioTrack
+import android.media.MediaRecorder
+import android.util.Base64
+import android.util.Log
+import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.modules.core.DeviceEventManagerModule
 
-@ReactModule(name = DeepgramModule.NAME)
-class DeepgramModule(reactContext: ReactApplicationContext) :
-  NativeDeepgramSpec(reactContext) {
-
-  override fun getName(): String {
-    return NAME
-  }
-
-  // Example method
-  // See https://reactnative.dev/docs/native-modules-android
-  override fun multiply(a: Double, b: Double): Double {
-    return a * b
-  }
+/**
+ * Native module that records raw PCM audio and plays back base64 encoded
+ * PCM chunks. Audio data recorded from the microphone is emitted to JS as the
+ * `AudioChunk` event.
+ */
+class DeepgramModule(private val reactContext: ReactApplicationContext) :
+  ReactContextBaseJavaModule(reactContext) {
 
   companion object {
     const val NAME = "Deepgram"
+    private const val TAG = "DeepgramModule"
+    private const val SAMPLE_RATE = 16000
+    private const val CHANNEL_CONFIG = AudioFormat.CHANNEL_IN_MONO
+    private const val AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT
+  }
+
+  private val minBufferSize: Int =
+    AudioRecord.getMinBufferSize(SAMPLE_RATE, CHANNEL_CONFIG, AUDIO_FORMAT)
+  private var bufferSize: Int = minBufferSize * 4
+
+  private var audioRecord: AudioRecord? = null
+  private var recordingThread: Thread? = null
+  private var isRecording = false
+
+  private var audioTrack: AudioTrack? = null
+
+  override fun getName() = NAME
+
+  // -------------------------------------------------------------------
+  // Recording
+  // -------------------------------------------------------------------
+
+  @ReactMethod
+  fun startRecording(promise: Promise) {
+    if (isRecording) {
+      promise.resolve(null)
+      return
+    }
+
+    try {
+      audioRecord = AudioRecord(
+        MediaRecorder.AudioSource.VOICE_RECOGNITION,
+        SAMPLE_RATE,
+        CHANNEL_CONFIG,
+        AUDIO_FORMAT,
+        bufferSize
+      )
+
+      if (audioRecord?.state != AudioRecord.STATE_INITIALIZED) {
+        promise.reject("init_failed", "AudioRecord initialization failed")
+        return
+      }
+
+      audioRecord?.startRecording()
+      isRecording = true
+
+      startRecordingThread()
+      promise.resolve(null)
+    } catch (e: Exception) {
+      Log.e(TAG, "startRecording error", e)
+      promise.reject("start_error", e)
+    }
+  }
+
+  @ReactMethod
+  fun stopRecording(promise: Promise) {
+    try {
+      isRecording = false
+      recordingThread?.interrupt()
+      recordingThread = null
+      audioRecord?.stop()
+      audioRecord?.release()
+      audioRecord = null
+      promise.resolve(null)
+    } catch (e: Exception) {
+      Log.e(TAG, "stopRecording error", e)
+      promise.reject("stop_error", e)
+    }
+  }
+
+  private fun startRecordingThread() {
+    recordingThread = Thread {
+      try {
+        val buffer = ByteArray(bufferSize)
+        while (isRecording && audioRecord != null) {
+          val read = audioRecord!!.read(buffer, 0, buffer.size)
+          if (read > 0) {
+            sendAudioChunk(buffer.copyOf(read))
+          }
+        }
+      } catch (e: Exception) {
+        Log.e(TAG, "recording thread error", e)
+      }
+    }
+    recordingThread?.start()
+  }
+
+  private fun sendAudioChunk(byteArray: ByteArray) {
+    val map = WritableNativeMap()
+    val array = WritableNativeArray()
+    for (b in byteArray) {
+      array.pushInt(b.toInt())
+    }
+    map.putArray("data", array)
+    reactContext
+      .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+      .emit("AudioChunk", map)
+  }
+
+  // -------------------------------------------------------------------
+  // Playback
+  // -------------------------------------------------------------------
+
+  private fun ensureAudioTrack() {
+    if (audioTrack != null) return
+
+    val channelMask = AudioFormat.CHANNEL_OUT_MONO
+    val minBuf = AudioTrack.getMinBufferSize(SAMPLE_RATE, channelMask, AUDIO_FORMAT)
+
+    audioTrack = AudioTrack.Builder()
+      .setAudioAttributes(
+        AudioAttributes.Builder()
+          .setUsage(AudioAttributes.USAGE_MEDIA)
+          .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+          .build()
+      )
+      .setAudioFormat(
+        AudioFormat.Builder()
+          .setEncoding(AUDIO_FORMAT)
+          .setSampleRate(SAMPLE_RATE)
+          .setChannelMask(channelMask)
+          .build()
+      )
+      .setBufferSizeInBytes(minBuf)
+      .setTransferMode(AudioTrack.MODE_STREAM)
+      .build()
+  }
+
+  @ReactMethod
+  fun startAudio(promise: Promise) {
+    try {
+      ensureAudioTrack()
+      audioTrack?.play()
+      promise.resolve(null)
+    } catch (e: Exception) {
+      Log.e(TAG, "startAudio error", e)
+      promise.reject("audio_start_error", e)
+    }
+  }
+
+  @ReactMethod
+  fun stopAudio(promise: Promise) {
+    try {
+      audioTrack?.stop()
+      audioTrack?.release()
+      audioTrack = null
+      promise.resolve(null)
+    } catch (e: Exception) {
+      Log.e(TAG, "stopAudio error", e)
+      promise.reject("audio_stop_error", e)
+    }
+  }
+
+  @ReactMethod
+  fun playAudioChunk(chunk: String, promise: Promise) {
+    try {
+      ensureAudioTrack()
+      val audioData = Base64.decode(chunk, Base64.DEFAULT)
+      audioTrack?.write(audioData, 0, audioData.size)
+      promise.resolve(null)
+    } catch (e: Exception) {
+      Log.e(TAG, "playAudioChunk error", e)
+      promise.reject("play_error", e)
+    }
   }
 }

--- a/android/src/main/java/com/deepgram/DeepgramPackage.kt
+++ b/android/src/main/java/com/deepgram/DeepgramPackage.kt
@@ -1,33 +1,19 @@
 package com.deepgram
 
-import com.facebook.react.BaseReactPackage
+import com.facebook.react.ReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.module.model.ReactModuleInfo
-import com.facebook.react.module.model.ReactModuleInfoProvider
-import java.util.HashMap
+import com.facebook.react.uimanager.ViewManager
 
-class DeepgramPackage : BaseReactPackage() {
-  override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
-    return if (name == DeepgramModule.NAME) {
-      DeepgramModule(reactContext)
-    } else {
-      null
-    }
+/**
+ * Package exposing the {@link DeepgramModule} to React Native.
+ */
+class DeepgramPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+    return listOf(DeepgramModule(reactContext))
   }
 
-  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider {
-    return ReactModuleInfoProvider {
-      val moduleInfos: MutableMap<String, ReactModuleInfo> = HashMap()
-      moduleInfos[DeepgramModule.NAME] = ReactModuleInfo(
-        DeepgramModule.NAME,
-        DeepgramModule.NAME,
-        false,  // canOverrideExistingModule
-        false,  // needsEagerInit
-        false,  // isCxxModule
-        true // isTurboModule
-      )
-      moduleInfos
-    }
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> {
+    return emptyList()
   }
 }

--- a/ios/Deepgram.h
+++ b/ios/Deepgram.h
@@ -1,5 +1,5 @@
-#import <DeepgramSpec/DeepgramSpec.h>
+#import <React/RCTEventEmitter.h>
+#import <React/RCTBridgeModule.h>
 
-@interface Deepgram : NSObject <NativeDeepgramSpec>
-
+@interface Deepgram : RCTEventEmitter <RCTBridgeModule>
 @end

--- a/ios/Deepgram.mm
+++ b/ios/Deepgram.mm
@@ -1,18 +1,124 @@
 #import "Deepgram.h"
+#import <AVFoundation/AVFoundation.h>
+
+@interface Deepgram()
+@property(nonatomic,strong) AVAudioEngine *engine;
+@property(nonatomic,strong) AVAudioPlayerNode *player;
+@end
 
 @implementation Deepgram
-RCT_EXPORT_MODULE()
 
-- (NSNumber *)multiply:(double)a b:(double)b {
-    NSNumber *result = @(a * b);
+RCT_EXPORT_MODULE();
 
-    return result;
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
 }
 
-- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
-    (const facebook::react::ObjCTurboModule::InitParams &)params
+- (NSArray<NSString *> *)supportedEvents
 {
-    return std::make_shared<facebook::react::NativeDeepgramSpecJSI>(params);
+  return @["DeepgramAudioPCM"];
+}
+
+#pragma mark - Recording
+
+RCT_EXPORT_METHOD(startRecording:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  @try {
+    if (!self.engine) {
+      self.engine = [[AVAudioEngine alloc] init];
+    }
+    AVAudioInputNode *input = self.engine.inputNode;
+    AVAudioFormat *format = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16 sampleRate:16000 channels:1 interleaved:YES];
+    [input removeTapOnBus:0];
+    __weak typeof(self) weakSelf = self;
+    [input installTapOnBus:0 bufferSize:1024 format:format block:^(AVAudioPCMBuffer *buffer, AVAudioTime *when) {
+      if (!weakSelf) return;
+      NSUInteger frames = buffer.frameLength;
+      int16_t *samples = buffer.int16ChannelData[0];
+      NSMutableArray *array = [NSMutableArray arrayWithCapacity:frames * 2];
+      for (NSUInteger i = 0; i < frames; i++) {
+        [array addObject:@(samples[i] & 0xFF)];
+        [array addObject:@((samples[i] >> 8) & 0xFF)];
+      }
+      [weakSelf sendEventWithName:@"DeepgramAudioPCM" body:@{ @"data": array }];
+    }];
+    [self.engine prepare];
+    [self.engine startAndReturnError:nil];
+    resolve(nil);
+  } @catch (NSException *e) {
+    reject(@"record_start_error", e.reason, nil);
+  }
+}
+
+RCT_EXPORT_METHOD(stopRecording:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  @try {
+    [self.engine.inputNode removeTapOnBus:0];
+    [self.engine stop];
+    self.engine = nil;
+    resolve(nil);
+  } @catch (NSException *e) {
+    reject(@"record_stop_error", e.reason, nil);
+  }
+}
+
+#pragma mark - Playback
+
+- (void)ensurePlayer
+{
+  if (!self.engine) {
+    self.engine = [[AVAudioEngine alloc] init];
+  }
+  if (!self.player) {
+    self.player = [[AVAudioPlayerNode alloc] init];
+    [self.engine attachNode:self.player];
+    AVAudioFormat *format = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16 sampleRate:16000 channels:1 interleaved:YES];
+    [self.engine connect:self.player to:self.engine.mainMixerNode format:format];
+    [self.engine prepare];
+    [self.engine startAndReturnError:nil];
+  }
+}
+
+RCT_EXPORT_METHOD(startAudio:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  @try {
+    [self ensurePlayer];
+    [self.player play];
+    resolve(nil);
+  } @catch (NSException *e) {
+    reject(@"audio_start_error", e.reason, nil);
+  }
+}
+
+RCT_EXPORT_METHOD(stopAudio:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  @try {
+    [self.player stop];
+    [self.engine stop];
+    self.player = nil;
+    self.engine = nil;
+    resolve(nil);
+  } @catch (NSException *e) {
+    reject(@"audio_stop_error", e.reason, nil);
+  }
+}
+
+RCT_EXPORT_METHOD(playAudioChunk:(NSString *)chunk resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject)
+{
+  @try {
+    [self ensurePlayer];
+    NSData *data = [[NSData alloc] initWithBase64EncodedString:chunk options:0];
+    if (!data) { reject(@"decode_error", @"invalid base64", nil); return; }
+    AVAudioFormat *format = [[AVAudioFormat alloc] initWithCommonFormat:AVAudioPCMFormatInt16 sampleRate:16000 channels:1 interleaved:YES];
+    AVAudioPCMBuffer *buffer = [[AVAudioPCMBuffer alloc] initWithPCMFormat:format frameCapacity:(uint32_t)(data.length / 2)];
+    buffer.frameLength = buffer.frameCapacity;
+    memcpy(buffer.int16ChannelData[0], data.bytes, data.length);
+    [self.player scheduleBuffer:buffer completionHandler:nil];
+    resolve(nil);
+  } @catch (NSException *e) {
+    reject(@"play_error", e.reason, nil);
+  }
 }
 
 @end

--- a/package.json
+++ b/package.json
@@ -95,6 +95,11 @@
   "workspaces": [
     "example"
   ],
+  "expo": {
+    "plugins": [
+      "./plugins/withDeepgramPackage"
+    ]
+  },
   "packageManager": "yarn@3.6.1",
   "jest": {
     "preset": "react-native",

--- a/plugins/withDeepgramPackage.js
+++ b/plugins/withDeepgramPackage.js
@@ -1,0 +1,31 @@
+const { withMainApplication } = require('@expo/config-plugins');
+
+function addPackage(src) {
+  const pkgImport = 'import com.deepgram.DeepgramPackage;';
+  const pkgInstance = 'packages.add(new DeepgramPackage());';
+
+  if (!src.includes(pkgImport)) {
+    src = src.replace(/^(package[\s\S]*?;)/, `$1\n${pkgImport}`);
+  }
+
+  if (!src.includes(pkgInstance)) {
+    src = src.replace(
+      /(new PackageList\(this\).getPackages\(\);)/,
+      `$1\n            ${pkgInstance}`
+    );
+  }
+
+  return src;
+}
+
+module.exports = function withDeepgramPackage(config) {
+  return withMainApplication(config, (cfg) => {
+    if (
+      cfg.modResults.language === 'java' ||
+      cfg.modResults.language === 'kt'
+    ) {
+      cfg.modResults.contents = addPackage(cfg.modResults.contents);
+    }
+    return cfg;
+  });
+};

--- a/src/NativeDeepgram.ts
+++ b/src/NativeDeepgram.ts
@@ -11,7 +11,7 @@ interface DeepgramNative {
 const LINKING_ERROR = `react-native-deepgram: Native code not linked—did you run “pod install” & rebuild?`;
 
 export const Deepgram: DeepgramNative =
-  NativeModules.DeepgramNative ??
+  NativeModules.Deepgram ??
   (new Proxy(
     {},
     {

--- a/src/useDeepgramConversation.ts
+++ b/src/useDeepgramConversation.ts
@@ -167,7 +167,7 @@ export const useDeepgramConversation: UseConversationHook = ({
           };
 
           /* Forward PCM chunks ➜ WebSocket */
-          const emitter = new NativeEventEmitter(NativeModules.DeepgramNative);
+          const emitter = new NativeEventEmitter(NativeModules.Deepgram);
           audioSub.current = emitter.addListener(
             AUDIO_EVT_NATIVE,
             ({ data }: { data: number[] }) => {


### PR DESCRIPTION
## Summary
- implement audio recording and playback in `DeepgramModule` for Android
- expose `DeepgramPackage` as a standard ReactPackage
- implement iOS recording and playback with `AVAudioEngine`
- add Expo config plugin to auto-link the package
- adjust JS to use `NativeModules.Deepgram` and register Android events

## Testing
- `yarn lint`
- `yarn test`
