### PR TITLE
Improve docs and example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,22 @@
 # react-native-deepgram
 
-Package to support deepgram
+Bindings that allow a React Native app to talk to
+[Deepgram's Voice Agent](https://developers.deepgram.com)
+service. The library handles recording raw PCM audio, connecting to the
+Deepgram WebSocket and playing back the agent's audio responses.
 
 ## Installation
 
 ```sh
 npm install react-native-deepgram
+# or
+yarn add react-native-deepgram
 ```
 
-## Usage
+### Expo
 
-
-```js
-import { useDeepgramConversation, configure } from 'react-native-deepgram';
-
-configure({ apiKey: 'YOUR_DEEPGRAM_API_KEY' });
-const { startSession, stopSession } = useDeepgramConversation({
-  onMessage: console.log,
-});
-```
-
-When using Expo, include the provided config plugin in your `app.json`:
+If you use Expo, add the config plugin in your `app.json` so the native Android
+package is registered automatically:
 
 ```json
 {
@@ -29,6 +25,42 @@ When using Expo, include the provided config plugin in your `app.json`:
   }
 }
 ```
+
+After installing, remember to run `pod install` inside the `ios` directory when
+developing for iOS.
+
+## Usage
+
+Configure the API key once, then use the `useDeepgramConversation` hook to start
+and stop a voice session.
+
+```tsx
+import React, { useState } from 'react';
+import { Button, Text, View } from 'react-native';
+import { configure, useDeepgramConversation } from 'react-native-deepgram';
+
+configure({ apiKey: 'YOUR_DEEPGRAM_API_KEY' });
+
+export default function Example() {
+  const [messages, setMessages] = useState([]);
+  const { startSession, stopSession } = useDeepgramConversation({
+    onMessage: (m) => setMessages((cur) => [...cur, m]),
+    onError: console.warn,
+  });
+
+  return (
+    <View>
+      <Button title="Start" onPress={startSession} />
+      <Button title="Stop" onPress={stopSession} />
+      {messages.map((m, i) => (
+        <Text key={i}>{`${m.role}: ${m.content}`}</Text>
+      ))}
+    </View>
+  );
+}
+```
+
+See the [`example`](example) folder for a fully working application.
 
 
 ## Contributing

--- a/example/README.md
+++ b/example/README.md
@@ -1,97 +1,26 @@
-This is a new [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
+# Example app
 
-# Getting Started
+This folder contains a bare React Native application demonstrating how to use **react-native-deepgram**.
 
-> **Note**: Make sure you have completed the [Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) guide before proceeding.
+## Running the example
 
-## Step 1: Start Metro
+1. Install the workspace dependencies from the repo root:
 
-First, you will need to run **Metro**, the JavaScript build tool for React Native.
+   ```sh
+   yarn install
+   ```
 
-To start the Metro dev server, run the following command from the root of your React Native project:
+2. Start Metro from the `example` directory:
 
-```sh
-# Using npm
-npm start
+   ```sh
+   cd example
+   yarn start
+   ```
 
-# OR using Yarn
-yarn start
-```
+3. In another terminal run the platform target:
 
-## Step 2: Build and run your app
+   ```sh
+   yarn ios       # or yarn android
+   ```
 
-With Metro running, open a new terminal window/pane from the root of your React Native project, and use one of the following commands to build and run your Android or iOS app:
-
-### Android
-
-```sh
-# Using npm
-npm run android
-
-# OR using Yarn
-yarn android
-```
-
-### iOS
-
-For iOS, remember to install CocoaPods dependencies (this only needs to be run on first clone or after updating native deps).
-
-The first time you create a new project, run the Ruby bundler to install CocoaPods itself:
-
-```sh
-bundle install
-```
-
-Then, and every time you update your native dependencies, run:
-
-```sh
-bundle exec pod install
-```
-
-For more information, please visit [CocoaPods Getting Started guide](https://guides.cocoapods.org/using/getting-started.html).
-
-```sh
-# Using npm
-npm run ios
-
-# OR using Yarn
-yarn ios
-```
-
-If everything is set up correctly, you should see your new app running in the Android Emulator, iOS Simulator, or your connected device.
-
-This is one way to run your app — you can also build it directly from Android Studio or Xcode.
-
-## Step 3: Modify your app
-
-Now that you have successfully run the app, let's make changes!
-
-Open `App.tsx` in your text editor of choice and make some changes. When you save, your app will automatically update and reflect these changes — this is powered by [Fast Refresh](https://reactnative.dev/docs/fast-refresh).
-
-When you want to forcefully reload, for example to reset the state of your app, you can perform a full reload:
-
-- **Android**: Press the <kbd>R</kbd> key twice or select **"Reload"** from the **Dev Menu**, accessed via <kbd>Ctrl</kbd> + <kbd>M</kbd> (Windows/Linux) or <kbd>Cmd ⌘</kbd> + <kbd>M</kbd> (macOS).
-- **iOS**: Press <kbd>R</kbd> in iOS Simulator.
-
-## Congratulations! :tada:
-
-You've successfully run and modified your React Native App. :partying_face:
-
-### Now what?
-
-- If you want to add this new React Native code to an existing application, check out the [Integration guide](https://reactnative.dev/docs/integration-with-existing-apps).
-- If you're curious to learn more about React Native, check out the [docs](https://reactnative.dev/docs/getting-started).
-
-# Troubleshooting
-
-If you're having issues getting the above steps to work, see the [Troubleshooting](https://reactnative.dev/docs/troubleshooting) page.
-
-# Learn More
-
-To learn more about React Native, take a look at the following resources:
-
-- [React Native Website](https://reactnative.dev) - learn more about React Native.
-- [Getting Started](https://reactnative.dev/docs/environment-setup) - an **overview** of React Native and how setup your environment.
-- [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
-- [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
-- [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+Make sure you replace `YOUR_API_KEY` in `src/App.tsx` with a valid Deepgram key before running the app.

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,20 +1,45 @@
-import { Text, View, StyleSheet } from 'react-native';
-import { configure } from 'react-native-deepgram';
+import React, { useState } from 'react';
+import { SafeAreaView, View, Text, Button, FlatList, StyleSheet } from 'react-native';
+import { configure, useDeepgramConversation } from 'react-native-deepgram';
 
 configure({ apiKey: 'YOUR_API_KEY' });
 
 export default function App() {
+  const [messages, setMessages] = useState([]);
+  const { startSession, stopSession } = useDeepgramConversation({
+    onMessage: (m) => setMessages((cur) => [...cur, m]),
+    onError: console.warn,
+  });
+
   return (
-    <View style={styles.container}>
-      <Text>Deepgram Example</Text>
-    </View>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.buttons}>
+        <Button title="Start" onPress={startSession} />
+        <Button title="Stop" onPress={stopSession} />
+      </View>
+      <FlatList
+        style={styles.list}
+        data={messages}
+        keyExtractor={(_, i) => String(i)}
+        renderItem={({ item }) => (
+          <Text>{`${item.role}: ${item.content}`}</Text>
+        )}
+      />
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    padding: 24,
+  },
+  buttons: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 12,
+  },
+  list: {
+    flex: 1,
   },
 });


### PR DESCRIPTION
## Summary
- expand README with installation and usage details
- simplify example README and add instructions
- show simple conversation in example app

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657787c2648326a57d9e1899da1421